### PR TITLE
Fix socket on Linux hanging up when server is processing things.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('file_socket', 'c', 'cpp',
-  default_options: ['c_std=c11', 'cpp_std=c++11', 'default_library=static'])
+  default_options: ['c_std=c11', 'cpp_std=c++11', 'default_library=static', 'warning_level=3', 'werror=true'])
 
 incdir = include_directories('src')
 compiler = meson.get_compiler('cpp')
@@ -26,6 +26,7 @@ sources_tests = [
   'src/ipc.cpp',
   'tests/ipc_tests.cpp'
 ]
+
 
 executable('ipc_server',
   sources_serv,

--- a/src/socket_windows.cpp
+++ b/src/socket_windows.cpp
@@ -65,7 +65,7 @@ int SocketImplementation::send(int socket_handle, const char *msg, size_t len) {
 	pfd.fd = socket_handle;
 	pfd.events = POLLWRNORM;
 
-	if (SocketImplementation::poll(&pfd) == -1) {
+	if (SocketImplementation::poll(&pfd, 100) == -1) {
 		SocketImplementation::perror("poll waiting error");
 		return -1;
 	} else if (pfd.revents & POLLWRNORM) {

--- a/tests/ipc_client.cpp
+++ b/tests/ipc_client.cpp
@@ -3,7 +3,7 @@
 #define SOCKET_NAME "ipc_test.socket"
 
 void Receive(const char *string, int strlen) {
-	printf("server got message: %s\n", string);
+	printf("client got message: %s length %d\n", string, strlen);
 }
 
 int main() {

--- a/tests/ipc_server.cpp
+++ b/tests/ipc_server.cpp
@@ -3,7 +3,7 @@
 #define SOCKET_NAME "ipc_test.socket"
 
 void Receive(const char *string, int strlen) {
-	printf("server got message: %s\n", string);
+	printf("server got message: %s length %d\n", string, strlen);
 }
 
 int main() {


### PR DESCRIPTION
I added a timeout, and a poll method to wait for data to arrive. (100 ms)

Basically this meant that a client would hang up early, and cause a broken pipe.
Now we wait a sensible amount of time for the server to reply and poll the socket.
If we get no reply then we know something is broken.

Enabled warnings, as highest level and they register as compiler errors too.