### PR TITLE
Fix windows socket polling and misc issues

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,0 +1,31 @@
+name: 🗔 Windows Builds
+on: [push, pull_request]
+
+jobs:
+  build-linux-meson:
+    name: Meson compile and test
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install meson
+        run: |
+          pip install meson
+      # make windows builds actually work - meson detects msvc incorrectly.
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Meson setup
+        run: |
+          meson setup build
+      - name: meson compile
+        working-directory: build/
+        run: |
+          meson compile
+
+      - name: Run tests
+        run: |
+          ./build/ipc_tests.exe

--- a/src/socket_windows.cpp
+++ b/src/socket_windows.cpp
@@ -33,8 +33,8 @@ void SocketImplementation::finalize() {
 int SocketImplementation::create_af_unix_socket(
 		struct sockaddr_un &name,
 		const char *file_path) {
-	const int socket_id = (int)socket(AF_UNIX, SOCK_STREAM, 0);
-	if (socket_id == -1) {
+	const SOCKET socket_id = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (socket_id == SOCKET_ERROR) {
 		perror("client socket");
 		return -1;
 	}
@@ -45,7 +45,7 @@ int SocketImplementation::create_af_unix_socket(
 	name.sun_family = AF_UNIX;
 	strncpy(name.sun_path, file_path, sizeof(name.sun_path) - 1);
 
-	return socket_id;
+	return (int)socket_id;
 }
 
 /*
@@ -73,7 +73,7 @@ int SocketImplementation::send(int socket_handle, const char *msg, size_t len) {
 		SocketImplementation::perror("poll waiting error");
 		return -1;
 	} else if (pfd.revents & POLLWRNORM) {
-		printf("waiting for write [%d] %s \n", __LINE__, __FILE__);
+		//printf("waiting for write [%d] %s \n", __LINE__, __FILE__);
 
 		int OK = ::send(socket_handle, msg, (int)len, 0);
 		if (OK == -1) {
@@ -92,13 +92,14 @@ int SocketImplementation::recv(int socket_handle, char *buffer, size_t bufferSiz
 	pfd.fd = socket_handle;
 	pfd.events = POLLRDNORM;
 
-	if (SocketImplementation::poll(&pfd) == -1) {
+	if (SocketImplementation::poll(&pfd, 100) == -1) {
 		SocketImplementation::perror("poll read error");
 		return -1;
 	} else if (pfd.revents & POLLRDNORM) {
-		printf("waiting for recv [%d] %s \n", __LINE__, __FILE__);
+		//printf("waiting for recv [%d] %s \n", __LINE__, __FILE__);
 
 		int OK = ::recv(socket_handle, buffer, (int)bufferSize, 0);
+
 		if (OK == -1) {
 			SocketImplementation::perror("cant read message");
 			SocketImplementation::close(socket_handle);
@@ -107,6 +108,7 @@ int SocketImplementation::recv(int socket_handle, char *buffer, size_t bufferSiz
 			return OK;
 		}
 	}
+
 	return 0;
 }
 
@@ -139,7 +141,7 @@ void SocketImplementation::close(int socket_handle) {
 }
 
 void SocketImplementation::unlink(const char *unlink_file) {
-	_unlink(unlink_file);
+	DeleteFile(unlink_file);
 }
 
 void SocketImplementation::perror(const char *msg) {

--- a/tests/ipc_tests.cpp
+++ b/tests/ipc_tests.cpp
@@ -61,7 +61,7 @@ TEST_CASE("varying delays sending test") {
 
 	for (int x = 0; x < 100000; x++) {
 		char hello[256];
-		int n = sprintf(hello, "hello %d", x);
+		int n = snprintf(hello, 64, "hello %d", x);
 		CHECK_GT(n, 0);
 		//char hello[] = "Hello World!" + x;
 		CHECK(client.setup_one_shot(SOCKET_NAME, hello, strlen(hello)));


### PR DESCRIPTION
- Socket poll was broken in recv and returning instantly (added 100ms the same as posix)
- _unlink should be DeleteFile
- disabled socket prints (they are ultra slow on windows)
- moved a cast to the return type - also SOCKET_ERROR seems to be broken by WinSock...
- ensured IPC buffers are zero before they are written to.
- deliberately kept buffer inside class in the memset code, as then we have no allocations/deallocations for the buffer, just read write but not create the entire thing each time and move the address